### PR TITLE
Updates experience section with new entry and added some items to techstack

### DIFF
--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -18,6 +18,20 @@ interface Experience {
 
 const experiences: Experience[] = [
   {
+    id: 'ods-delaware',
+    title: 'Casual/Seasonal IT Support Technician',
+    company: 'Office of Defence Services, State of Delaware',
+    location: 'Wilmington, DE',
+    period: 'September 2025 - Present',
+    description: 'Gained hands-on experience in IT infrastructure management and process optimization for healthcare services.',
+    achievements: [
+      'Assisted in the deployment and configuration of new workstations, ensuring compliance with organizational standards',
+      'Provided technical support for software and hardware issues, improving resolution times by 20%',
+    ],
+    skills: ['IT Infrastructure', 'System Administration', 'Documentation'],
+    icon: '⚖️'
+  },
+  {
     id: 'rcm-internship',
     title: 'IT Intern',
     company: 'RCM Healthcare Services',

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -24,7 +24,7 @@ const projects: Project[] = [
     description: 'Enterprise-grade virtualization setup with automated monitoring, backup systems, and container orchestration. Features Discord webhook notifications and Grafana dashboards.',
     image: '/Homelab-Dashboard.png',
     githubUrl: 'https://github.com/Bbocks/Docker-Compose-Files.git',
-    techStack: ['Proxmox', 'Docker', 'Grafana', 'Prometheus', 'Discord Webhooks', 'Ansible'],
+    techStack: ['Proxmox', 'Docker', 'Grafana', 'Prometheus', 'Discord Webhooks', 'Bash', 'Linux', 'ZFS'],
     category: 'homelab',
     terminalCommands: [
       'ssh root@proxmox.local',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an ODS Delaware IT Support Technician experience and expands the homelab project's tech stack.
> 
> - **Experience**:
>   - Adds new entry `ods-delaware` (Casual/Seasonal IT Support Technician) with details in `src/components/ExperienceSection.tsx`.
> - **Projects**:
>   - Updates `homelab` project tech stack in `src/components/ProjectsSection.tsx` to include `Bash`, `Linux`, and `ZFS` (keeping `Proxmox`, `Docker`, `Grafana`, `Prometheus`, `Discord Webhooks`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0da56f7b70198c7fbfce79467a2957f5d9e9811b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->