### PR TITLE
Mobile: thin terminal bar + tips sheet (hints / help button); desktop unchanged

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -21,7 +21,8 @@ const tegakiCaveatFont = {
 
 const ROLE_PHRASES = [
   'Computer Science Graduate', 
-  'Developer', 'DevOps Designer/Engineer', 
+  'Developer', 
+  'DevOps Designer/Engineer', 
   'Network Technician', 
   'Homelab Enthusiast'
 ] as const

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -19,7 +19,12 @@ const tegakiCaveatFont = {
   fontFaceCSS: `@font-face { font-family: '${caveat.family}'; src: url(${assetBase}/fonts/tegaki/caveat-3dc76002.ttf); } @font-face { font-family: '${caveat.fullFamily}'; src: url(${assetBase}/fonts/tegaki/caveat.ttf); }`,
 } as const
 
-const ROLE_PHRASES = ['Computer Science Graduate', 'Developer', 'DevOps Designer/Engineer', 'Network Technician', 'Homelab Enthusiast'] as const
+const ROLE_PHRASES = [
+  'Computer Science Graduate', 
+  'Developer', 'DevOps Designer/Engineer', 
+  'Network Technician', 
+  'Homelab Enthusiast'
+] as const
 
 interface HeroSectionProps {
   /** When true, used inside the portfolio shell (no full-page scroll section, compact chrome). */

--- a/src/components/shell/CommandTerminal.tsx
+++ b/src/components/shell/CommandTerminal.tsx
@@ -1,21 +1,60 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
+import { HelpCircle } from 'lucide-react'
 import TerminalPanel from '../terminal/TerminalPanel'
 import type { TerminalLine } from '../../lib/terminalCommands'
+
+export type CommandTerminalVariant = 'full' | 'compact'
 
 interface CommandTerminalProps {
   lines: TerminalLine[]
   onSubmitLine: (raw: string) => void
   className?: string
   contentClassName?: string
+  /** `compact` = single input row + optional help button (mobile). `full` = desktop log + panel chrome. */
+  variant?: CommandTerminalVariant
+  /** Shown only in `compact` variant; opens the tips sheet. */
+  onOpenHelp?: () => void
 }
 
-const CommandTerminal = ({ lines, onSubmitLine, className = '', contentClassName = '' }: CommandTerminalProps) => {
+const CommandTerminal = ({
+  lines,
+  onSubmitLine,
+  className = '',
+  contentClassName = '',
+  variant = 'full',
+  onOpenHelp,
+}: CommandTerminalProps) => {
   const logRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const el = logRef.current
     if (el) el.scrollTop = el.scrollHeight
   }, [lines])
+
+  if (variant === 'compact') {
+    return (
+      <div
+        className={`rounded-lg border border-[var(--color-border)] bg-[var(--color-panel)] shadow-[0_0_0_1px_rgba(56,189,248,0.06),0_4px_16px_rgba(0,0,0,0.25)] ${className}`}
+      >
+        <TerminalInput
+          onSubmit={onSubmitLine}
+          compact
+          trailing={
+            onOpenHelp ? (
+              <button
+                type="button"
+                onClick={onOpenHelp}
+                className="shrink-0 rounded-md p-1.5 text-[var(--color-terminal)] hover:bg-[var(--color-bg-elevated)] focus-visible:focus-ring"
+                aria-label="Open terminal tips"
+              >
+                <HelpCircle className="h-5 w-5" aria-hidden />
+              </button>
+            ) : null
+          }
+        />
+      </div>
+    )
+  }
 
   return (
     <TerminalPanel
@@ -51,12 +90,20 @@ const CommandTerminal = ({ lines, onSubmitLine, className = '', contentClassName
           </div>
         ))}
       </div>
-      <TerminalInput onSubmit={onSubmitLine} />
+      <TerminalInput onSubmit={onSubmitLine} compact={false} />
     </TerminalPanel>
   )
 }
 
-function TerminalInput({ onSubmit }: { onSubmit: (raw: string) => void }) {
+function TerminalInput({
+  onSubmit,
+  compact = false,
+  trailing,
+}: {
+  onSubmit: (raw: string) => void
+  compact?: boolean
+  trailing?: ReactNode
+}) {
   return (
     <form
       onSubmit={(e) => {
@@ -66,7 +113,11 @@ function TerminalInput({ onSubmit }: { onSubmit: (raw: string) => void }) {
         onSubmit(raw)
         e.currentTarget.reset()
       }}
-      className="flex shrink-0 items-center gap-2 border-t border-[var(--color-border-subtle)] bg-[var(--color-panel-header)]/80 px-3 py-2"
+      className={`flex shrink-0 items-center gap-2 border-[var(--color-border-subtle)] bg-[var(--color-panel-header)]/80 ${
+        compact
+          ? 'border-none px-2 py-1.5'
+          : 'border-t border-[var(--color-border-subtle)] px-3 py-2'
+      }`}
     >
       <span className="shrink-0 font-mono text-[var(--color-accent)]" aria-hidden>
         &gt;
@@ -79,6 +130,7 @@ function TerminalInput({ onSubmit }: { onSubmit: (raw: string) => void }) {
         autoComplete="off"
         spellCheck={false}
       />
+      {trailing}
     </form>
   )
 }

--- a/src/components/shell/PortfolioShell.tsx
+++ b/src/components/shell/PortfolioShell.tsx
@@ -4,6 +4,7 @@ import { usePostHog } from 'posthog-js/react'
 import HeroSection from '../HeroSection'
 import HeroWelcome from './HeroWelcome'
 import CommandTerminal from './CommandTerminal'
+import TerminalHelpSheet from './TerminalHelpSheet'
 import ProjectsSection from '../ProjectsSection'
 import ExperienceSection from '../ExperienceSection'
 import SkillsSection from '../SkillsSection'
@@ -20,6 +21,7 @@ const PortfolioShell = () => {
     typeof window !== 'undefined' ? parseViewFromHash() : 'home',
   )
   const [terminalLines, setTerminalLines] = useState<TerminalLine[]>(TERMINAL_BOOT_LINES)
+  const [terminalHelpOpen, setTerminalHelpOpen] = useState(false)
   const mainRef = useRef<HTMLElement>(null)
   const prefersReducedMotion = useReducedMotion()
   const isLg = useIsLg()
@@ -48,6 +50,14 @@ const PortfolioShell = () => {
   }, [activeView])
 
   useEffect(() => {
+    setTerminalHelpOpen(false)
+  }, [activeView])
+
+  useEffect(() => {
+    if (isLg) setTerminalHelpOpen(false)
+  }, [isLg])
+
+  useEffect(() => {
     posthog?.capture('portfolio_section_changed', { section: activeView })
   }, [activeView, posthog])
 
@@ -62,6 +72,21 @@ const PortfolioShell = () => {
       setTerminalLines((prev) => [...prev, { kind: 'out', text: helpText() }])
       return
     }
+    if ('openHelp' in parsed && parsed.openHelp) {
+      if (isLg) {
+        setTerminalLines((prev) => [
+          ...prev,
+          {
+            kind: 'out',
+            text: 'Tips panel is for the compact mobile bar. Type help for the full command list here.',
+          },
+        ])
+      } else {
+        setTerminalHelpOpen(true)
+        setTerminalLines((prev) => [...prev, { kind: 'out', text: '→ tips' }])
+      }
+      return
+    }
     if ('error' in parsed) {
       setTerminalLines((prev) => [...prev, { kind: 'err', text: parsed.error }])
       return
@@ -70,7 +95,7 @@ const PortfolioShell = () => {
       setTerminalLines((prev) => [...prev, { kind: 'out', text: `→ ${parsed.view}` }])
       setActiveView(parsed.view)
     }
-  }, [])
+  }, [isLg])
 
   const enter = prefersReducedMotion ? { opacity: 1 } : { opacity: 0, x: 16 }
   const animate = { opacity: 1, x: 0 }
@@ -173,9 +198,18 @@ const PortfolioShell = () => {
         </main>
 
         {!isLg && (
-          <div className="h-[min(40vh,280px)] min-h-[200px] shrink-0 border-t border-[var(--color-border-subtle)] bg-[var(--color-bg-deep)] p-2">
-            <CommandTerminal lines={terminalLines} onSubmitLine={onSubmitLine} className="h-full" />
-          </div>
+          <>
+            {terminalHelpOpen && <TerminalHelpSheet onClose={() => setTerminalHelpOpen(false)} />}
+            <div className="shrink-0 border-t border-[var(--color-border-subtle)] bg-[var(--color-bg-deep)] px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-1.5">
+              <CommandTerminal
+                variant="compact"
+                lines={terminalLines}
+                onSubmitLine={onSubmitLine}
+                onOpenHelp={() => setTerminalHelpOpen(true)}
+                className="w-full"
+              />
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/src/components/shell/TerminalHelpSheet.tsx
+++ b/src/components/shell/TerminalHelpSheet.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react'
+import { X } from 'lucide-react'
+import { helpText, mobileTipsIntro } from '../../lib/terminalCommands'
+
+interface TerminalHelpSheetProps {
+  onClose: () => void
+}
+
+/** Bottom-sheet tips for mobile shell; mount only when visible. */
+const TerminalHelpSheet = ({ onClose }: TerminalHelpSheetProps) => {
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    const id = window.requestAnimationFrame(() => closeRef.current?.focus())
+    return () => window.cancelAnimationFrame(id)
+  }, [])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div className="fixed inset-0 z-[70] flex flex-col justify-end lg:hidden">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/60 backdrop-blur-[2px]"
+        aria-label="Close tips"
+        onClick={onClose}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="terminal-help-title"
+        className="relative z-[71] max-h-[min(85dvh,560px)] overflow-hidden rounded-t-xl border border-[var(--color-border)] border-b-0 bg-[var(--color-panel)] shadow-[0_-8px_40px_rgba(0,0,0,0.45)]"
+      >
+        <div className="flex items-center justify-between border-b border-[var(--color-border-subtle)] bg-[var(--color-panel-header)] px-4 py-3">
+          <h2 id="terminal-help-title" className="font-mono text-sm font-semibold text-[var(--color-text)]">
+            Terminal tips
+          </h2>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-2 text-[var(--color-text-muted)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text)] focus-visible:focus-ring"
+            aria-label="Close tips"
+          >
+            <X className="h-5 w-5" aria-hidden />
+          </button>
+        </div>
+        <div className="max-h-[calc(min(85dvh,560px)-3.5rem)] overflow-y-auto px-4 py-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+          <p className="mb-4 text-sm leading-relaxed text-[var(--color-text-muted)]">{mobileTipsIntro()}</p>
+          <pre className="whitespace-pre-wrap rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg-deep)] p-3 font-mono text-[11px] leading-relaxed text-[var(--color-text-muted)] sm:text-xs">
+            {helpText()}
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TerminalHelpSheet

--- a/src/lib/terminalCommands.ts
+++ b/src/lib/terminalCommands.ts
@@ -24,10 +24,16 @@ const NAV_ALIASES: Record<string, PortfolioView> = {
 export function helpText(): string {
   return `Commands:
   help              Show this list
+  hints | guide     Open tips panel (small screens)
   home              Back to hero / welcome
   projects | experience | skills | homelab | blog | contact
   cd <page>         Same as typing the page name
   open <page>       Same as cd`
+}
+
+/** Short intro shown above the command list in the mobile tips sheet. */
+export function mobileTipsIntro(): string {
+  return 'On mobile, only the command line is shown so content uses most of the screen. Type a command below or open this panel with hints, guide, or the help button on the right of the bar. Command output appears in the full terminal on desktop.'
 }
 
 function normalizeTokens(line: string): string[] {
@@ -38,13 +44,19 @@ function normalizeTokens(line: string): string[] {
     .filter(Boolean)
 }
 
-/** Returns target view, or null if not a navigation command (e.g. help only). */
-export function parseNavigationCommand(line: string): { view: PortfolioView } | { help: true } | { error: string } {
+/** Parsed shell input: navigate, show help, open mobile tips, or error. */
+export function parseNavigationCommand(
+  line: string,
+): { view: PortfolioView } | { help: true } | { openHelp: true } | { error: string } {
   const tokens = normalizeTokens(line)
   if (tokens.length === 0) return { error: '(empty)' }
 
   if (tokens[0] === 'help' || tokens[0] === '?') {
     return { help: true }
+  }
+
+  if (tokens[0] === 'hints' || tokens[0] === 'guide' || tokens[0] === 'directions') {
+    return { openHelp: true }
   }
 
   if (tokens[0] === 'cd' || tokens[0] === 'open') {


### PR DESCRIPTION
### Summary

Implements the **mobile terminal compact + help** behavior: on viewports below `lg`, the bottom shell is a **single-line command bar** (prompt, input, help icon) so **most of the viewport stays for section content**. A **bottom-sheet “Terminal tips”** dialog explains navigation, notes that full command output appears in the **desktop** terminal, and documents **`hints` / `guide` / `directions`**. **Desktop** keeps the existing full **`CommandTerminal`** (panel chrome + scrollback + input) in the left rail—**no layout or UX change** there.

### User-facing changes

- **Mobile**
  - Removed the tall terminal block (`~40vh` / `min-height`); footer is **content-sized** with light padding + safe-area inset.
  - **`CommandTerminal` `variant="compact"`**: no log, no traffic-light header—only the input row + **`HelpCircle`** button on the right.
  - **`TerminalHelpSheet`**: opens from the help button or commands **`hints`**, **`guide`**, or **`directions`**; dismiss with **backdrop**, **Close (X)**, or **Escape**; `role="dialog"` + labeled title for a11y.
  - Tips sheet **closes** when navigating to another section, when **`activeView`** changes, or when resizing to **`lg`**.
- **Desktop (`lg+`)**
  - Same **`CommandTerminal`** as before (default **`full`**). Typing **`hints` / `guide` / `directions`** appends a short informational line instead of opening the sheet (tips UI is mobile-only).

### Commands / copy

- **`helpText()`** updated to list **`hints | guide`** (and parser accepts **`directions`**).
- **`mobileTipsIntro()`** in [`src/lib/terminalCommands.ts`](src/lib/terminalCommands.ts) supplies the short intro above the command list in the sheet.

### Files

| Area | Files |
|------|--------|
| Parsing | [`src/lib/terminalCommands.ts`](src/lib/terminalCommands.ts) — `{ openHelp: true }`, `helpText`, `mobileTipsIntro` |
| UI | [`src/components/shell/TerminalHelpSheet.tsx`](src/components/shell/TerminalHelpSheet.tsx) (new) |
| Terminal | [`src/components/shell/CommandTerminal.tsx`](src/components/shell/CommandTerminal.tsx) — `variant` `full` \| `compact`, `onOpenHelp`, `HelpCircle` |
| Shell | [`src/components/shell/PortfolioShell.tsx`](src/components/shell/PortfolioShell.tsx) — `terminalHelpOpen`, mobile wrapper, `onSubmitLine` branches, dismiss effects |

### How to test

1. **Mobile / narrow:** confirm main content fills the screen; bar is one line; **help** opens sheet; **`hints`** opens sheet; **`help`** in sheet matches terminal **`help`** output; Escape / backdrop / X close sheet.
2. **Navigate** (`projects`, etc.) with sheet open → sheet should close.
3. **Resize to desktop** → sheet should not appear; full terminal + **`help`** output unchanged; **`hints`** prints the desktop-only hint line.
4. **`npm run build`** passes.

### Related

Implements **Mobile terminal: thin input bar + directions popup** 